### PR TITLE
Reduced width of Professional box

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
 	<div class="bgrid">
 		<div class="price-block">
 			<div style="background:#EAEAED;padding-top:1rem;" align="center">
-      	 		 <iframe src="newsletters/PR.html" frameborder="0" marginheight="0" onload="resizeIframe(this)" scrolling="no" width="500px"></iframe>
+      	 		 <iframe src="newsletters/PR.html" frameborder="0" marginheight="0" onload="resizeIframe(this)" scrolling="no" width="480px"></iframe>
     		</div>      
 	</div> <!-- /price-block -->      
       </div> <!-- /professional-tables -->


### PR DESCRIPTION
Reduced the width of the Professional Opportunities box from 500px to 480px. This allows the entire box to fit on the page without any cutoffs. It now looks good next to the MotM list box.