### PR TITLE
Fix the navbar overlap issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,9 +74,9 @@
 					<li><a class="smoothscroll"  href="#professional" title="">professional</a></li>
 					<li><a class="smoothscroll"  href="#outreach" title="">Outreach</a></li>
           				<li><a class="smoothscroll"  href="#contact" title="">Contact</a></li>
+					<li><a class="smoothscroll"  href="https://docs.google.com/forms/d/e/1FAIpQLSdI5XZ8JtLlOGS7X64lockrE5-CmrxU-3A6DQSvZs20UheNAw/viewform?usp=sf_link" title="">Attendance</a></li>
+					<li><a class="smoothscroll"  href="letters.html" title="">Newsletters and Slides</a></li>
                                         <li class="highlight with-sep"><a href="https://squareup.com/store/ans-at-uiuc" title="">Market</a></li>
-					<li class="highlight with-sep"><a href="https://docs.google.com/forms/d/e/1FAIpQLSdI5XZ8JtLlOGS7X64lockrE5-CmrxU-3A6DQSvZs20UheNAw/viewform?usp=sf_link" title="">Attendance</a></li>
-					<li class="highlight with-sep"><a href="letters.html" title="">Newsletters and Slides</a></li>
 				</ul>
 			</nav>
 

--- a/index.html
+++ b/index.html
@@ -58,15 +58,13 @@
   <!-- header
   ================================================== -->
   <header>
- 	  <div class="row">
-
-   		<div class="logo">
+	  <div class="logo">
         <a class="ans" href="http://www.ans.org/">ANS national</a>
         <a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
         <a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
 	<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
       </div>
-
+ 	  <div class="row">
 	   	<nav id="main-nav-wrap">
 				<ul class="main-navigation">
 					<li class="current"><a class="smoothscroll"  href="#intro" title="">Home</a></li>
@@ -74,9 +72,9 @@
 					<li><a class="smoothscroll"  href="#professional" title="">professional</a></li>
 					<li><a class="smoothscroll"  href="#outreach" title="">Outreach</a></li>
           				<li><a class="smoothscroll"  href="#contact" title="">Contact</a></li>
-					<li><a class="smoothscroll"  href="https://docs.google.com/forms/d/e/1FAIpQLSdI5XZ8JtLlOGS7X64lockrE5-CmrxU-3A6DQSvZs20UheNAw/viewform?usp=sf_link" title="">Attendance</a></li>
-					<li><a class="smoothscroll"  href="letters.html" title="">Newsletters and Slides</a></li>
                                         <li class="highlight with-sep"><a href="https://squareup.com/store/ans-at-uiuc" title="">Market</a></li>
+					<li class="highlight with-sep"><a href="https://docs.google.com/forms/d/e/1FAIpQLSdI5XZ8JtLlOGS7X64lockrE5-CmrxU-3A6DQSvZs20UheNAw/viewform?usp=sf_link" title="">Attendance</a></li>
+					<li class="highlight with-sep"><a href="letters.html" title="">Newsletters and Slides</a></li>
 				</ul>
 			</nav>
 

--- a/letters.html
+++ b/letters.html
@@ -43,24 +43,23 @@
 
   <!-- header
   ================================================== -->
-  <header style="z-index: 2;">
- 	  <div class="row">
-
-   		<div class="logo">
-        <a class="ans" href="http://www.ans.org/">ANS at UIUC</a>
-        <a class="facebook" href="http://www.facebook.com/">ANS at UIUC Facebook</a>
-        <a class="twitter" href="http://www.twitter.com/">ANS at UIUC Twitter</a>
-	<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel</a>
+   <header>
+	  <div class="logo">
+        <a class="ans" href="http://www.ans.org/">ANS national</a>
+        <a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
+        <a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
+	<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
       </div>
-
+ 	  <div class="row">
 	   	<nav id="main-nav-wrap">
 				<ul class="main-navigation">
-					<li><a href="index.html#intro" title="">Home</a></li>
-					<li><a href="index.html#calendar" title="">Calendar</a></li>
-					<li><a href="index.html#professional" title="">professional</a></li>
-					<li><a href="index.html#outreach" title="">Outreach</a></li>
-          				<li><a href="index.html#faq" title="">Contact</a></li>
-					<li><a href="https://squareup.com/store/ans-at-uiuc" title="">Market</a></li>
+					<li class="current"><a class="smoothscroll"  href="#intro" title="">Home</a></li>
+					<li><a class="smoothscroll"  href="#calendar" title="">Calendar</a></li>
+					<li><a class="smoothscroll"  href="#professional" title="">professional</a></li>
+					<li><a class="smoothscroll"  href="#outreach" title="">Outreach</a></li>
+          				<li><a class="smoothscroll"  href="#contact" title="">Contact</a></li>
+                                        <li class="highlight with-sep"><a href="https://squareup.com/store/ans-at-uiuc" title="">Market</a></li>
+					<li class="highlight with-sep"><a href="https://docs.google.com/forms/d/e/1FAIpQLSdI5XZ8JtLlOGS7X64lockrE5-CmrxU-3A6DQSvZs20UheNAw/viewform?usp=sf_link" title="">Attendance</a></li>
 					<li class="highlight with-sep"><a href="letters.html" title="">Newsletters and Slides</a></li>
 				</ul>
 			</nav>


### PR DESCRIPTION
This PR moves the logos in the navbar outside the div class rows to fix the overlap issue. It also copys the bar to the letters.html page as well so that they are identical. We should probably explore creating separate _includes files so that this is not an issue going forward. 