### PR TITLE
Fix the header overlaps

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -837,7 +837,7 @@ header .logo a.slack {
 	width: 42px;
 	height: 42px;
 	margin: 0;
-	padding: 0;
+	padding: 10px;
 	margin-bottom: 2rem;
 	border: none;
 	font: 0/0 a;

--- a/css/main.css
+++ b/css/main.css
@@ -822,7 +822,7 @@ header .row {
 header .logo {
 	margin-top: 2px;
 	z-index: 600;
-	position: relative;
+	position: absolute;
 	left: 35px;
 	top: 50%;
 	-webkit-transform: translateY(-50%);
@@ -837,7 +837,7 @@ header .logo a.slack {
 	width: 42px;
 	height: 42px;
 	margin: 0;
-	padding: 10px;
+	padding: 5px;
 	margin-bottom: 2rem;
 	border: none;
 	font: 0/0 a;

--- a/css/main.css
+++ b/css/main.css
@@ -817,13 +817,14 @@ header .row {
 	width: auto;
 	height: 66px;
 	position: relative;
+	padding: 30px;
 }
 
 header .logo {
 	margin-top: 2px;
 	z-index: 600;
 	position: absolute;
-	left: 35px;
+	left: 20px;
 	top: 50%;
 	-webkit-transform: translateY(-50%);
 	-ms-transform: translateY(-50%);
@@ -837,7 +838,7 @@ header .logo a.slack {
 	width: 42px;
 	height: 42px;
 	margin: 0;
-	padding: 5px;
+	padding: 0;
 	margin-bottom: 2rem;
 	border: none;
 	font: 0/0 a;
@@ -1007,7 +1008,7 @@ a.menu-toggle {
  * -
  */
 
-@media only screen and (max-width:768px) {
+@media only screen and (max-width:1200px) {
 	#main-nav-wrap {
 		display: block;
 		width: 100%;
@@ -1152,7 +1153,7 @@ a.menu-toggle {
  * -
  */
 
-@media only screen and (min-width:769px) {
+@media only screen and (min-width:1200px) {
 	#main-nav-wrap ul.main-navigation {
 		display: block !important;
 	}

--- a/css/main.css
+++ b/css/main.css
@@ -822,7 +822,7 @@ header .row {
 header .logo {
 	margin-top: 2px;
 	z-index: 600;
-	position: absolute;
+	position: relative;
 	left: 35px;
 	top: 50%;
 	-webkit-transform: translateY(-50%);

--- a/index.html
+++ b/index.html
@@ -58,14 +58,14 @@
   <!-- header
   ================================================== -->
   <header>
-	  <div class="logo">
-        <a class="ans" href="http://www.ans.org/">ANS national</a>
-        <a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
-        <a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
-	<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
-      </div>
  	  <div class="row">
 	   	<nav id="main-nav-wrap">
+			<div class="logo">
+				<a class="ans" href="http://www.ans.org/">ANS national</a>
+				<a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
+				<a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
+				<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
+		        </div>
 				<ul class="main-navigation">
 					<li class="current"><a class="smoothscroll"  href="#intro" title="">Home</a></li>
 					<li><a class="smoothscroll"  href="#calendar" title="">Calendar</a></li>

--- a/index.html
+++ b/index.html
@@ -59,14 +59,14 @@
   ================================================== -->
   <header>
  	  <div class="row">
+      <div class="logo">
+        <a class="ans" href="http://www.ans.org/">ANS national</a>
+        <a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
+        <a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
+        <a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
+            </div>
 	   	<nav id="main-nav-wrap">
 				<ul class="main-navigation">
-					<div class="logo">
-						<a class="ans" href="http://www.ans.org/">ANS national</a>
-						<a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
-						<a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
-						<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
-		        		</div>
 					<li class="current"><a class="smoothscroll"  href="#intro" title="">Home</a></li>
 					<li><a class="smoothscroll"  href="#calendar" title="">Calendar</a></li>
 					<li><a class="smoothscroll"  href="#professional" title="">professional</a></li>

--- a/index.html
+++ b/index.html
@@ -60,13 +60,13 @@
   <header>
  	  <div class="row">
 	   	<nav id="main-nav-wrap">
-			<div class="logo">
-				<a class="ans" href="http://www.ans.org/">ANS national</a>
-				<a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
-				<a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
-				<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
-		        </div>
 				<ul class="main-navigation">
+					<div class="logo">
+						<a class="ans" href="http://www.ans.org/">ANS national</a>
+						<a class="facebook" href="https://www.facebook.com/groups/ANSatUofI/">ANS at UIUC facebook</a>
+						<a class="twitter" href="https://twitter.com/ANS_Illinois/">ANS at UIUC twitter </a>
+						<a class="slack" href="https://ansuiuc.slack.com/">ANS at UIUC Slack Channel </a>
+		        		</div>
 					<li class="current"><a class="smoothscroll"  href="#intro" title="">Home</a></li>
 					<li><a class="smoothscroll"  href="#calendar" title="">Calendar</a></li>
 					<li><a class="smoothscroll"  href="#professional" title="">professional</a></li>


### PR DESCRIPTION
This pr changes the max and min widths required to activate the web header so that the logos don't overlap with the nav bar. This pr can be merged if it is deemed an efficient and aesthetically appropriate address of the issue raised in the 8/16 exec board meeting. 